### PR TITLE
Update default type convetion to ForwardSlash

### DIFF
--- a/core/branch.go
+++ b/core/branch.go
@@ -67,7 +67,7 @@ var typeConvention = TypeConvention{
 }
 
 //Default TC
-var typeConventionSelected = typeConvention.Underscore
+var typeConventionSelected = typeConvention.ForwardSlash
 
 //namingConvention values
 var namingConvention = NamingConvention{


### PR DESCRIPTION
IMO it's should be default for separator name and branch type to make easier to read naming of branch.